### PR TITLE
[Feature/admin-account] 실행시 admin 계정 자동 생성 구현

### DIFF
--- a/charlee-web/build.gradle
+++ b/charlee-web/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/charlee-web/src/main/java/com/efa73/charleeweb/CharleeWebApplication.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/CharleeWebApplication.java
@@ -2,8 +2,10 @@ package com.efa73.charleeweb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@ConfigurationPropertiesScan
 @EnableJpaAuditing
 @SpringBootApplication
 public class CharleeWebApplication {

--- a/charlee-web/src/main/java/com/efa73/charleeweb/common/Common.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/common/Common.java
@@ -20,16 +20,8 @@ public abstract class Common {
     @Column(nullable = false, updatable = false)
     protected LocalDateTime createdAt;
 
-//    @CreatedBy
-//    @Column(nullable = false, updatable = false)
-//    private User createdBy;
-
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
     protected LocalDateTime updatedAt;
-
-//    @LastModifiedBy
-//    @Column(nullable = false)
-//    private User modifiedBy;
 }

--- a/charlee-web/src/main/java/com/efa73/charleeweb/config/AdminInitializer.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/config/AdminInitializer.java
@@ -1,0 +1,38 @@
+package com.efa73.charleeweb.config;
+
+import com.efa73.charleeweb.user.domain.Role;
+import com.efa73.charleeweb.user.domain.User;
+import com.efa73.charleeweb.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AdminInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AdminProperties adminProperties;
+
+    private String adminName;
+    private String adminEmail;
+    private String adminPassword;
+
+    @PostConstruct
+    private void init() {
+        this.adminName = adminProperties.getName();
+        this.adminEmail = adminProperties.getEmail();
+        this.adminPassword = adminProperties.getPassword();
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (!userRepository.existsByRole(Role.ADMIN)) {
+            User admin = User.from(adminName, adminEmail, passwordEncoder.encode(adminPassword), null, Role.ADMIN);
+            userRepository.save(admin);
+        }
+    }
+}

--- a/charlee-web/src/main/java/com/efa73/charleeweb/config/AdminProperties.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/config/AdminProperties.java
@@ -1,0 +1,15 @@
+package com.efa73.charleeweb.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "admin")
+public class AdminProperties {
+
+    private final String name;
+    private final String email;
+    private final String password;
+}

--- a/charlee-web/src/main/java/com/efa73/charleeweb/config/SecurityConfig.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package com.efa73.charleeweb.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+//        return new BCryptPasswordEncoder();
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/charlee-web/src/main/java/com/efa73/charleeweb/config/SecurityConfig.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/config/SecurityConfig.java
@@ -10,7 +10,6 @@ public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-//        return new BCryptPasswordEncoder();
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/charlee-web/src/main/java/com/efa73/charleeweb/user/dto/UserRegisterDto.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/user/dto/UserRegisterDto.java
@@ -38,10 +38,4 @@ public record UserRegisterDto(
                 user.getUpdatedAt()
         );
     }
-
-//    public User toEntity() {
-//        return User.of(
-//
-//        )
-//    }
 }

--- a/charlee-web/src/main/java/com/efa73/charleeweb/user/dto/UserRegisterDto.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/user/dto/UserRegisterDto.java
@@ -1,0 +1,47 @@
+package com.efa73.charleeweb.user.dto;
+
+import com.efa73.charleeweb.user.domain.Role;
+import com.efa73.charleeweb.user.domain.User;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link com.efa73.charleeweb.user.domain.User}
+ */
+public record UserRegisterDto(
+        Long id,
+        String name,
+        String email,
+        String phone,
+        Role role,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static UserRegisterDto of(Long id, String name, String email, String phone, Role role) {
+        return new UserRegisterDto(id, name, email, phone, role, null, null);
+    }
+
+    public static UserRegisterDto of(Long id, String name, String email, String phone, Role role,
+                                     LocalDateTime createdAt,
+                                     LocalDateTime updatedAt) {
+        return new UserRegisterDto(id, name, email, phone, role, createdAt, updatedAt);
+    }
+
+    public static UserRegisterDto from(User user) {
+        return new UserRegisterDto(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getPhone(),
+                user.getRole(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+
+//    public User toEntity() {
+//        return User.of(
+//
+//        )
+//    }
+}

--- a/charlee-web/src/main/java/com/efa73/charleeweb/user/dto/UserRegisterRequest.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/user/dto/UserRegisterRequest.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 /**
  * DTO for {@link com.efa73.charleeweb.user.domain.User}
  */
-public record UserRegisterDto(
+public record UserRegisterRequest(
         Long id,
         String name,
         String email,
@@ -17,18 +17,18 @@ public record UserRegisterDto(
         LocalDateTime updatedAt
 ) {
 
-    public static UserRegisterDto of(Long id, String name, String email, String phone, Role role) {
-        return new UserRegisterDto(id, name, email, phone, role, null, null);
+    public static UserRegisterRequest of(Long id, String name, String email, String phone, Role role) {
+        return new UserRegisterRequest(id, name, email, phone, role, null, null);
     }
 
-    public static UserRegisterDto of(Long id, String name, String email, String phone, Role role,
-                                     LocalDateTime createdAt,
-                                     LocalDateTime updatedAt) {
-        return new UserRegisterDto(id, name, email, phone, role, createdAt, updatedAt);
+    public static UserRegisterRequest of(Long id, String name, String email, String phone, Role role,
+                                         LocalDateTime createdAt,
+                                         LocalDateTime updatedAt) {
+        return new UserRegisterRequest(id, name, email, phone, role, createdAt, updatedAt);
     }
 
-    public static UserRegisterDto from(User user) {
-        return new UserRegisterDto(
+    public static UserRegisterRequest from(User user) {
+        return new UserRegisterRequest(
                 user.getId(),
                 user.getEmail(),
                 user.getName(),

--- a/charlee-web/src/main/java/com/efa73/charleeweb/user/repository/UserRepository.java
+++ b/charlee-web/src/main/java/com/efa73/charleeweb/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.efa73.charleeweb.user.repository;
+
+import com.efa73.charleeweb.user.domain.Role;
+import com.efa73.charleeweb.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByRole(Role role);
+}

--- a/charlee-web/src/main/resources/application.yml
+++ b/charlee-web/src/main/resources/application.yml
@@ -22,4 +22,3 @@ admin:
   name: ${ADMIN_NAME}
   email: ${ADMIN_EMAIL}
   password: ${ADMIN_PASSWORD}
->>>>>>> 7ce9466 (chore: jwt, admin 관련 환경변수 추가)

--- a/charlee-web/src/main/resources/application.yml
+++ b/charlee-web/src/main/resources/application.yml
@@ -17,3 +17,9 @@ spring:
 jwt:
   expiration_time: ${JWT_EXP_TIME}
   secret: ${JWT_SECRET}
+
+admin:
+  name: ${ADMIN_NAME}
+  email: ${ADMIN_EMAIL}
+  password: ${ADMIN_PASSWORD}
+>>>>>>> 7ce9466 (chore: jwt, admin 관련 환경변수 추가)


### PR DESCRIPTION
### Summary
애플리케이션 실행시 admin 계정 자동 생성 구현

### Description
<!-- 구체적인 작업 내용, 필요시 이미지 첨부 -->
CharleeWebApplication
- @ConfigurationPropertiesScan 추가
- 환경변수 application.yml 속성과 바인딩

application.yml
- spring-boot-configuration-processor 의존성 추가
- 환경변수 자동 바인딩을 위해 추가
- admin 계정 환경변수 등록

Common
- 주석처리 해놓은 createdBy, modifiedBy 필드 제거

AdminInitializer
- 애플리케이션 실행시 admin 계정이 없다면 하나 생성
- name, email, password로 생성

AdminProperties
- application.yml에 지정한 admin 속성을 객체로 만들어서 사용

SecurityConfig
- passwordEncoder 메서드 추가

UserRegisterDto
- of, from 메서드로 dto 객체 생성

UserRepository
- 역할 별 계정이 있는지 확인하기 위한 existsByRole 메서드 추가
- 주로 admin 계정이 있는지 확인하기 위한 용도

### Discussion
<!-- 추후 논의할 점 -->
- admin 계정 공유 필요


### Issue Number or Link
<!-- 예시: closes #issue-number -->
close #20 